### PR TITLE
Fix chatbot visibility to hide only when cart is open

### DIFF
--- a/frontend/src/Components/Cart/Cart.css
+++ b/frontend/src/Components/Cart/Cart.css
@@ -6,14 +6,13 @@
 }
 
 .offcanvas.offcanvas-end {
-  width: 400px;
+  width: 550px;
   max-width: 100%;
   background-color: #ffffff;
   box-shadow: -4px 0 15px rgba(0, 0, 0, 0.1);
   z-index: 1055;
 }
 
-/* Header */
 .offcanvas-header {
   padding: 1rem 1.5rem;
   border-bottom: 1px solid #eee;
@@ -25,7 +24,6 @@
   color: #333;
 }
 
-/* Empty Cart State */
 .empty-cart {
   padding-top: 2rem;
 }

--- a/frontend/src/Components/Cart/Cart.jsx
+++ b/frontend/src/Components/Cart/Cart.jsx
@@ -1,5 +1,5 @@
 import { Context } from "../../utils/Context";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import "../Cart/Cart.css";
 import CartItems from "./CartItems/CartItems";
 import { makePaymentRequest } from "../../utils/api";
@@ -15,8 +15,24 @@ const Cart = () => {
   const { cartItems, cartSubTotal } = useContext(Context);
   const [showCheckoutForm, setShowCheckoutForm] = useState(false);
   const [paymentSuccess, setPaymentSuccess] = useState(false);
+  const { setIsCartOpen } = useContext(Context);
 
   const handleCheckoutClick = () => setShowCheckoutForm(true);
+
+  useEffect(() => {
+    const cartEl = document.getElementById("offcanvasRight");
+
+    const handleOpen = () => setIsCartOpen(true);
+    const handleClose = () => setIsCartOpen(false);
+
+    cartEl?.addEventListener("show.bs.offcanvas", handleOpen);
+    cartEl?.addEventListener("hidden.bs.offcanvas", handleClose);
+
+    return () => {
+      cartEl?.removeEventListener("show.bs.offcanvas", handleOpen);
+      cartEl?.removeEventListener("hidden.bs.offcanvas", handleClose);
+    };
+  }, []);
 
   return (
     <div className="offcanvas offcanvas-end" tabIndex="-1" id="offcanvasRight">
@@ -27,6 +43,7 @@ const Cart = () => {
           type="button"
           className="btn-close"
           data-bs-dismiss="offcanvas"
+          onClick={() => setIsCartOpen(false)}
         ></button>
       </div>
       <hr />

--- a/frontend/src/Components/Chatbot/Chatbot.css
+++ b/frontend/src/Components/Chatbot/Chatbot.css
@@ -1,3 +1,10 @@
+:root {
+  --dark-color: #3074f0;
+  --primary-color: #f7c9d2;
+  --light-color: #f5f5f5;
+  --success-color: #8c8f94;
+}
+
 .chatbot-container {
   position: fixed;
   bottom: 20px;

--- a/frontend/src/Components/Chatbot/Chatbot.jsx
+++ b/frontend/src/Components/Chatbot/Chatbot.jsx
@@ -2,8 +2,13 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { sendChatbotMessage } from "../../utils/api";
 import "./Chatbot.css";
+import { useContext } from "react";
+import { Context } from "../../utils/Context";
 
 const Chatbot = () => {
+  const { isCartOpen } = useContext(Context);
+  if (isCartOpen) return null;
+
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState([

--- a/frontend/src/utils/Context.jsx
+++ b/frontend/src/utils/Context.jsx
@@ -10,6 +10,7 @@ const AppContext = ({ children }) => {
   const [cartItems, setCartItems] = useState([]);
   const [cartCount, setCartCount] = useState(0);
   const [cartSubTotal, setCartSubTotal] = useState(0);
+  const [isCartOpen, setIsCartOpen] = useState(false);
 
   //   const [total, setTotal] = useState(0);
   //   const [user, setUser] = useState(null);
@@ -94,6 +95,8 @@ const AppContext = ({ children }) => {
         handleAddToCart,
         handleRemoveFromCart,
         handleCartQuantity,
+        isCartOpen,
+        setIsCartOpen,
         // total,
         // setTotal,
         // user,


### PR DESCRIPTION
- Ensured the chatbot is visible on initial page load and only hidden when the cart sidebar is open.
- Replaced initial state toggle with Bootstrap offcanvas event listeners (`show.bs.offcanvas` and `hidden.bs.offcanvas`) to detect cart open/close.
- Chatbot component now conditionally renders only when cart is not open.
- Ensures chatbot is always visible on page load and reappears when cart closes.